### PR TITLE
added 'unload_zbarcam' that unload zbarcam.kv and xcamera.kv files

### DIFF
--- a/src/kivy_garden/zbarcam/zbarcam.py
+++ b/src/kivy_garden/zbarcam/zbarcam.py
@@ -208,22 +208,37 @@ class ZBarCam(AnchorLayout):
         self.xcamera.play = True
 
     def stop(self):
+        """
+        Stop xcamera, release device and unload
+        zbarcam.kv and xcamera.kv
+        """
         self.xcamera.play = False
+
+        # release device and unload kivy files
+        # in non android devices
+        if platform != "android":
+            self.xcamera._camera._device.release()
+            self._unload()
+
+        # release device in android devices
         if platform == "android":
             self.xcamera._camera._release_camera()
 
-    def unload_zbarcam(self):
+    def _unload(self):
+        """
+        Unload `zbarcam.kv` and `xcamera.kv` files
+        """
         if ZBarCam.kv_loaded:
             # unload zbarcam.kv
             zbar_kv_path = os.path.join(MODULE_DIRECTORY, 'zbarcam.kv')
             Builder.unload_file(zbar_kv_path)
 
             # unload xcamera.kv
-            mod_path = os.path.dirname(
-                sys.modules['kivy_garden.xcamera'].__file__
-            )
-            xcam_kv_path = os.path.join(mod_path, 'xcamera.kv')
+            module_path = sys.modules['kivy_garden.xcamera'].__file__
+            module_directory = os.path.dirname(module_path)
+            xcam_kv_path = os.path.join(module_directory, 'xcamera.kv')
             Builder.unload_file(xcam_kv_path)
 
-            # set kv_loaded = false
-            ZBarCam.kv_loaded = False
+            # sets kv_loaded
+            ZBarcam.kv_loaded = False
+

--- a/src/kivy_garden/zbarcam/zbarcam.py
+++ b/src/kivy_garden/zbarcam/zbarcam.py
@@ -213,7 +213,7 @@ class ZBarCam(AnchorLayout):
             self.xcamera._camera._release_camera()
 
     def unload_zbarcam(self):
-        id ZBarCam.kv_loaded:
+        if ZBarCam.kv_loaded:
             # unload zbarcam.kv
             zbar_kv_path = os.path.join(MODULE_DIRECTORY, 'zbarcam.kv')
             Builder.unload_file(zbar_kv_path)

--- a/src/kivy_garden/zbarcam/zbarcam.py
+++ b/src/kivy_garden/zbarcam/zbarcam.py
@@ -1,3 +1,4 @@
+import sys
 import os
 from collections import namedtuple
 
@@ -210,3 +211,19 @@ class ZBarCam(AnchorLayout):
         self.xcamera.play = False
         if platform == "android":
             self.xcamera._camera._release_camera()
+
+    def unload_zbarcam(self):
+        id ZBarCam.kv_loaded:
+            # unload zbarcam.kv
+            zbar_kv_path = os.path.join(MODULE_DIRECTORY, 'zbarcam.kv')
+            Builder.unload_file(zbar_kv_path)
+
+            # unload xcamera.kv
+            mod_path = os.path.dirname(
+                sys.modules['kivy_garden.xcamera'].__file__
+            )
+            xcam_kv_path = os.path.join(mod_path, 'xcamera.kv')
+            Builder.unload_file(xcam_kv_path)
+
+            # set kv_loaded = false
+            ZBarCam.kv_loaded = False


### PR DESCRIPTION
This PR add a `unload_zbarcam` method.

This method fixes the issue "[restart after releasing the camera results in these warnings followed by pages of errors](https://github.com/kivy-garden/zbarcam/issues/59#issuecomment-1280102277)"

The solution was to unload `zbarcam.kv` and `xcamera.kv` files (see this [response](https://github.com/kivy-garden/zbarcam/issues/59#issuecomment-1784158670)).

A working example with this approach can be found [here](https://github.com/qlrd/krux-file-signer/tree/kivy).

